### PR TITLE
Create new PRs. Fixes #22.

### DIFF
--- a/src/bin/fake_git.rs
+++ b/src/bin/fake_git.rs
@@ -3,14 +3,67 @@
 //! Used to facilitate testing scenarios where prescribed behavior is required, and would be too
 //! cumbersome to obtain from "real git". Should only be used in unit testing; integration tests
 //! should still run against an actual git binary.
-use std::env;
 use std::process::exit;
 
+
+// Grab a command line argument by its index
+//
+// ## Example: `./fake_git a --b sea`
+// * argv!(1) => "a"
+// * argv!(2) => "--b"
+// * argv!(3) => "sea"
+macro_rules! argv {
+    ($n:expr) => {
+        std::env::args().nth($n).as_deref()
+    };
+}
+
+
 fn main() {
-    let first_arg = env::args().nth(1);
-    match first_arg.as_deref() {
+    match argv!(1) {
+
+        // No input given
         None => exit(1),
+
+        // git checkout -b <anything>
+        Some("checkout") => match argv!(2) {
+            None => exit(1),
+            Some("-b") => match argv!(3) {
+                None => exit(1),
+                Some(_) => exit(0) // Any argument will do, return 0
+            },
+            Some(_) => exit(1)
+        },
+
+        // git push -u origin <anything>
+        Some("push") => match argv!(2) {
+            None => exit(1),
+            Some("-u") => match argv!(3) {
+                None => exit(1),
+                Some("origin") => match argv!(4) {
+                    None => exit(1),
+                    Some(_) => exit(0) // Any argument will do, return 0
+                },
+                Some(_) => exit(1)
+            },
+            Some(_) => exit(1)
+        },
+
+        // git rev-parse --short HEAD
+        Some("rev-parse") => match argv!(2) {
+            None => exit(1),
+            Some("--short") => match argv!(3) {
+                None => exit(1),
+                Some("HEAD") => println!("1234567"),
+                Some(_) => exit(1)
+            },
+            Some(_) => exit(1)
+        },
+
+        // git --version
         Some("--version") => println!("fake_git version 1"),
+
+        // unrecognized input
         Some(_) => exit(1)
     };
 

--- a/src/bin/git-pr-create.rs
+++ b/src/bin/git-pr-create.rs
@@ -1,3 +1,31 @@
-fn main() {
-    println!("Hello, world!");
+//! Create a new local branch with an associated upstream tracking branch for a pull request.
+//!
+//! This tool currently assumes 'origin' will be the name of the remote.
+use libgitpr;
+use std::env::args;
+use std::process::exit;
+
+
+fn main() -> Result<(),libgitpr::GitError> {
+
+    // We expect exactly one argument, a PR name.
+    match args().nth(1).as_deref() {
+        None => {
+            eprintln!("A Pull Request name is required: git pr-create <name>");
+            exit(1)
+        },
+        Some(name) => {
+            let git = libgitpr::Git::new();
+
+            // Find the current hash of HEAD, and create a new branch called "name/hash"
+            let hash = git.rev_parse_head()?;
+            let branch_name = format!("{}/{}",name,hash);
+            git.create_branch(&branch_name)?;
+
+            // Push that branch to the remote named *origin*
+            git.push_upstream(&branch_name)?;
+        }
+    }
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,8 +260,7 @@ mod tests {
     // fake_git returns a constant, known hash, so we check for that.
     #[test]
     fn get_hash_of_current_commit() {
-        let path = String::from("./target/release/fake_git");
-        let fake_git = Git::with_path(path);
+        let fake_git = Git::with_path(crate_target!("fake_git"));
         let hash = fake_git.rev_parse_head().unwrap();
         assert_eq!(hash, "1234567");
     }
@@ -271,8 +270,7 @@ mod tests {
     // appropriate for an integration test with real git.
     #[test]
     fn create_new_branch() {
-        let path = String::from("./target/release/fake_git");
-        let fake_git = Git::with_path(path);
+        let fake_git = Git::with_path(crate_target!("fake_git"));
         fake_git.create_branch("hotfix").unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,41 @@ impl Git {
 
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
     }
+
+    /// Get the hash of the HEAD commit.
+    ///
+    /// This is useful for creating new PR branches, since we can use this value as a way to
+    /// indicate the "base" of the current work. This function takes advantage of the `core.abbrev`
+    /// config value, and will return a hash of the indicated length. If this value is not
+    /// specificed, git will return the shortest hash necessary to uniquely identify the commit.
+    pub fn rev_parse_head(&self) -> Result<String,GitError> {
+        let output = Command::new(&self.program).args(&["rev-parse","--short","HEAD"]).output()?;
+        assert_success(output.status)?;
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim_end().to_string())
+    }
+
+    /// Create a new branch
+    ///
+    /// Used with [`rev_parse_head`] as part of the `git-pr-create` tool. Pull requests are
+    /// expressed as branches with a certain naming pattern (`pr-name/hash`). So in our system,
+    /// creating a branch and creating a pull request are the same operation!
+    pub fn create_branch(&self, name: &str) -> Result<(), GitError> {
+        let status = Command::new(&self.program).args(&["checkout","-b",name]).status()?;
+        assert_success(status)?;
+
+        Ok(())
+    }
+
+    /// Push a branch to `origin` and set upstream tracking
+    ///
+    /// Used in `git-pr-create` to notify other developers that a new PR has been created.
+    pub fn push_upstream(&self, name: &str) -> Result<(), GitError> {
+        let status = Command::new(&self.program).args(&["push","-u","origin",name]).status()?;
+        assert_success(status)?;
+
+        Ok(())
+    }
 }
 
 
@@ -217,5 +252,24 @@ mod tests {
         assert_eq!(pr_names[1], "second");
         assert_eq!(pr_names[2], "dabba/doo/third");
         assert_eq!(pr_names[3], "fourth");
+    }
+
+    // fake_git returns a constant, known hash, so we check for that.
+    #[test]
+    fn get_hash_of_current_commit() {
+        let path = String::from("./target/release/fake_git");
+        let fake_git = Git::with_path(path);
+        let hash = fake_git.rev_parse_head().unwrap();
+        assert_eq!(hash, "1234567");
+    }
+
+    // We call `create_branch` to ensure it doesn't throw an error, but we don't have enough
+    // tooling in `fake_git` to warrant checking for a change in state afterwards -- this is more
+    // appropriate for an integration test with real git.
+    #[test]
+    fn create_new_branch() {
+        let path = String::from("./target/release/fake_git");
+        let fake_git = Git::with_path(path);
+        fake_git.create_branch("hotfix").unwrap();
     }
 }

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -75,3 +75,27 @@ fn can_list_all_branches() {
     let branches = git.all_branches().unwrap();
     assert!(branches.contains("trunk"));
 }
+
+#[test]
+fn can_get_hash_of_head() {
+    println!("TempDir='{:?}'", TEST_STATE.path());
+
+    // The hash will change every time, but this is one of the few git commands for which we can
+    // know the exact length of the output. Weak, but best we can do until we add more capabilities
+    // to the client.
+    let git = Git::new();
+    let hash = git.rev_parse_head().unwrap();
+    assert_eq!(hash.len(), 7);
+}
+
+#[test]
+fn can_create_new_branch() {
+    println!("TempDir='{:?}'", TEST_STATE.path());
+
+    // Show that we can create a new branch in this repo, and verify its existence by querying the
+    // list of branches and showing that this new branch is among them.
+    let git = Git::new();
+    git.create_branch("knurt").unwrap();
+    let branches = git.all_branches().unwrap();
+    assert!(branches.contains("knurt"));
+}


### PR DESCRIPTION
This pr builds out the `git-pr-create` command. I took a few big deviations from our previous discussions which I should call out:

* I went back to assuming "origin" is the one and only remote. Because `git pr-create` implies `git push`, we need to know the name of a remote that will receive the pushed objects. I decided to punt on solving this and go with "origin".
* `fake_git` still doesn't do a lot, but it's now **much** more convoluted. I think what is there works... but perhaps we should switch to clap.
* There is no integration test for `Git::push_upstream` (git push -u) because I wasn't sure how to tackle that

If you aren't comfortable punting on these, then we can address them before merging, but I think they'll each require a bit of brainstorming.