### PR TITLE
Configure git user in temporary repo. Fixes #33

### DIFF
--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -15,18 +15,18 @@ impl TestState {
         let working_dir = TempDir::new(prefix).unwrap();
         set_current_dir(working_dir.path()).unwrap();
 
+        // git init in new unique dir
+        let status = Command::new("git").args(&["init"]).status().unwrap();
+        assert!(status.success());
+
         // Setup git config for email
         let status = Command::new("git")
-            .args(&["config","--global","user.email","you@example.com"]).status().unwrap();
+            .args(&["config","user.email","you@example.com"]).status().unwrap();
         assert!(status.success());
 
         // Setup git config for name
         let status = Command::new("git")
-            .args(&["config","--global","user.name","Your Name"]).status().unwrap();
-        assert!(status.success());
-
-        // git init in new unique dir
-        let status = Command::new("git").args(&["init"]).status().unwrap();
+            .args(&["config","user.name","Your Name"]).status().unwrap();
         assert!(status.success());
 
         // create trunk branch


### PR DESCRIPTION
@calebwherry pointed out the fix for this -- without thinking, I had
reflexively entered "--global" when setting up the git config, even
though this is supposed to be config values for the temporary repo. I
removed the "--global" flag and moved these commands *after* `git init`
because otherwise they would not have a `.git/config` upon which to
operate.