### PR TITLE
Detect merged branches. Affects #28.

### DIFF
--- a/src/bin/fake_git.rs
+++ b/src/bin/fake_git.rs
@@ -11,6 +11,11 @@ fn main() {
     match first_arg.as_deref() {
         None => exit(1),
         Some("--version") => println!("fake_git version 1"),
+        Some("branch") => match env::args().nth(2).as_deref() {
+            None => exit(1),
+            Some("--merged") => println!("* trunk\nalready-been-merged"),
+            Some(_) => exit(1)
+        }
         Some(_) => exit(1)
     };
 

--- a/src/bin/fake_git.rs
+++ b/src/bin/fake_git.rs
@@ -13,6 +13,11 @@ fn main() {
         Some("--version") => println!("fake_git version 1"),
         Some("branch") => match env::args().nth(2).as_deref() {
             None => exit(1),
+            Some("-d") => match env::args().nth(3).as_deref() {
+                None => exit(1),
+                Some("already-been-merged") => exit(0),
+                Some(_) => exit(1)
+            },
             Some("--merged") => println!("* trunk\nalready-been-merged"),
             Some(_) => exit(1)
         }

--- a/src/bin/fake_git.rs
+++ b/src/bin/fake_git.rs
@@ -62,9 +62,9 @@ fn main() {
 
         // git --version
         Some("--version") => println!("fake_git version 1"),
-        Some("branch") => match env::args().nth(2).as_deref() {
+        Some("branch") => match argv!(2) {
             None => exit(1),
-            Some("-d") => match env::args().nth(3).as_deref() {
+            Some("-d") => match argv!(3) {
                 None => exit(1),
                 Some("already-been-merged") => exit(0),
                 Some(_) => exit(1)

--- a/src/bin/git-pr-clean.rs
+++ b/src/bin/git-pr-clean.rs
@@ -1,3 +1,13 @@
-fn main() {
-    println!("Hello, world!");
+//! Remove local branches which have been merged into 'trunk'
+use libgitpr;
+
+fn main() -> Result<(),libgitpr::GitError> {
+    let git = libgitpr::Git::new();
+    let merged_branches = git.merged_branches()?;
+
+    for branch in libgitpr::extract_deletable_branches(&merged_branches) {
+        git.delete_branch(&branch)?;
+    }
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,13 +298,13 @@ mod tests {
 
     #[test]
     fn identify_branches_for_deletion() {
-        let mut merged_branches = vec![
+        let merged_branches = vec![
             "  one",
             "* two",
             "  trunk",
-            "  three"
+            "  three",
+            ""
         ].join("\n");
-        merged_branches.push_str("\n");
 
         let pr_names = extract_deletable_branches(&merged_branches);
         assert_eq!(pr_names.len(), 2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,13 @@ impl Git {
 
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
     }
+
+    pub fn merged_branches(&self) -> Result<String,GitError> {
+        let output = Command::new(&self.program).args(&["branch","--merged"]).output()?;
+        assert_success(output.status)?;
+
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
 }
 
 
@@ -217,5 +224,13 @@ mod tests {
         assert_eq!(pr_names[1], "second");
         assert_eq!(pr_names[2], "dabba/doo/third");
         assert_eq!(pr_names[3], "fourth");
+    }
+
+    #[test]
+    fn can_detect_merged_branches() {
+        let path = String::from("./target/release/fake_git");
+        let fake_git = Git::with_path(path);
+        let merged_branches = fake_git.merged_branches().unwrap();
+        assert!(merged_branches.contains("already-been-merged"));
     }
 }

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -38,6 +38,10 @@ impl TestState {
             .args(&["commit","--allow-empty","-m","hello"]).status().unwrap();
         assert!(status.success());
 
+        // create a fake branch to test deletion
+        let status = Command::new("git").args(&["branch","hotfix"]).status().unwrap();
+        assert!(status.success());
+
         Self{ working_dir }
     }
 
@@ -74,4 +78,13 @@ fn can_list_all_branches() {
     let git = Git::new();
     let branches = git.all_branches().unwrap();
     assert!(branches.contains("trunk"));
+}
+
+#[test]
+fn detect_merged_branches() {
+    println!("TempDir='{:?}'", TEST_STATE.path());
+
+    let git = Git::new();
+    let branches = git.merged_branches().unwrap();
+    assert!(branches.contains("hotfix"));
 }

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -96,6 +96,7 @@ fn could_clean() {
     git.delete_branch("hotfix").unwrap();
     let branches = git.all_branches().unwrap();
     assert!(!branches.contains("hotfix"));
+}
 
 #[test]
 fn can_get_hash_of_head() {

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -80,11 +80,20 @@ fn can_list_all_branches() {
     assert!(branches.contains("trunk"));
 }
 
+// Cleaning PRs requires that we identify "old" branches (those which have been merged into trunk),
+// and that we delete those branches. Because the tests run in parallel, we need to ensure that our
+// check for the existence of the "hotfix" branch always happens *before* our attempt to delete the
+// "hotfix" branch. So this test case exercises all the git client functionality we would need in
+// order to implement the "pr-clean" subcommand.
 #[test]
-fn detect_merged_branches() {
+fn could_clean() {
     println!("TempDir='{:?}'", TEST_STATE.path());
 
     let git = Git::new();
     let branches = git.merged_branches().unwrap();
     assert!(branches.contains("hotfix"));
+
+    git.delete_branch("hotfix").unwrap();
+    let branches = git.all_branches().unwrap();
+    assert!(!branches.contains("hotfix"));
 }


### PR DESCRIPTION
This ensures we can test for "merged branches", which will subsequently be deleted as part of `pr-clean`.