### PR TITLE
Get rid of lazy_static for regexes. Fixes #18.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 
 [dependencies]
 regex = "1"
-lazy_static = "1.4.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"
+lazy_static = "1.4.0"
 
 [lib]
 name = "libgitpr"


### PR DESCRIPTION
Still using it for `tests/real_git.rs` though.