### PR TITLE
Support hexadecimal iteration numbers for branches. Fixes #36

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,18 +166,18 @@ impl Git {
 /// criteria for pull request names is:
 ///
 /// * must begin with "remotes/origin/"
-/// * must end with one or more digits
+/// * must end with one or more hex digits
 pub fn extract_pr_names(branches: &str) -> Vec<String> {
 
     // It's okay to call `.unwrap()` here, because we know that the regexes compile as long as the
     // "parse_branches_into_pr_list" unit test passes.
     let begins_with_remote_ref: Regex = Regex::new(r"^ *\** remotes/origin/").unwrap();
-    let ends_with_digit: Regex = Regex::new(r"/\d+$").unwrap();
+    let ends_with_hex: Regex = Regex::new(r"/[a-f\d]+$").unwrap();
 
     // Select any branches which match *both* of the regexes defined above.
     let pr_branches: Vec<&str> = branches.lines()
         .filter(|b| begins_with_remote_ref.is_match(b))
-        .filter(|b| ends_with_digit.is_match(b))
+        .filter(|b| ends_with_hex.is_match(b))
         .collect();
 
     // Transform each branch "remotes/origin/blah/N" into a PR Name: "blah".  This has some
@@ -186,7 +186,7 @@ pub fn extract_pr_names(branches: &str) -> Vec<String> {
     let mut pr_names = vec![];
     for branch in pr_branches {
         let branch = begins_with_remote_ref.replace_all(&branch, "");
-        let branch = ends_with_digit.replace_all(&branch, "");
+        let branch = ends_with_hex.replace_all(&branch, "");
         pr_names.push(branch.to_string())
     }
 
@@ -253,8 +253,8 @@ mod tests {
           local-junk
         * stuff/I/wrote
           trunk
-          remotes/origin/first-pr/0
-          remotes/origin/second/3
+          remotes/origin/first-pr/000000
+          remotes/origin/second/f3f3f3
           remotes/origin/not-being-tracked
           remotes/origin/has-a-directory-but/still-not-being-tracked
         ";


### PR DESCRIPTION
Previously, the idea of the "iteration number" for a PR was an increasing sequence of decimal numbers. Now that we had adopted the idea of using the base commit's hash as the "iteration number", we need to be able to list branches that may include hexadecimal values.

I changed one of the unit tests to look for something like `pr-name/3f3f3f` instead of `pr-name/3`, and then I played around with the Regex until the tests all passed again. Ultimately, the solution was to use a "character class" consisting of `a-f` together with `\d` (digit), and to keep the existing quantifier.