### PR TITLE
Create a git repo for each test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,16 +21,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 name = "git-pr"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "regex",
  "tempdir",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ regex = "1"
 
 [dev-dependencies]
 tempdir = "0.3.7"
-lazy_static = "1.4.0"
 
 [lib]
 name = "libgitpr"

--- a/src/bin/fake_git.rs
+++ b/src/bin/fake_git.rs
@@ -25,6 +25,19 @@ fn main() {
         // No input given
         None => exit(1),
 
+        Some("-C") => match argv!(2) {
+            None => exit(1),
+            Some(_) => match argv!(3) {
+                None => exit(1),
+
+                // git --version
+                Some("--version") => println!("fake_git version 1"),
+
+                // unrecognized input
+                Some(_) => exit(1)
+            }
+        },
+
         // git checkout -b <anything>
         Some("checkout") => match argv!(2) {
             None => exit(1),
@@ -60,8 +73,6 @@ fn main() {
             Some(_) => exit(1)
         },
 
-        // git --version
-        Some("--version") => println!("fake_git version 1"),
         Some("branch") => match argv!(2) {
             None => exit(1),
             Some("-d") => match argv!(3) {

--- a/src/bin/fake_git.rs
+++ b/src/bin/fake_git.rs
@@ -33,10 +33,29 @@ fn main() {
                 // git --version
                 Some("--version") => println!("fake_git version 1"),
 
-                // git branch --merged
+                // git branch ...
                 Some("branch") => match argv!(4) {
                     None => exit(1),
+
+                    // git branch --merged
                     Some("--merged") => println!("* trunk\nalready-been-merged"),
+
+                    // git branch -d already-been-merged
+                    Some("-d") => match argv!(5) {
+                        None => exit(1),
+                        Some("already-been-merged") => exit(0),
+                        Some(_) => exit(1)
+                    },
+                    Some(_) => exit(1)
+                },
+
+                // git checkout -b <anything>
+                Some("checkout") => match argv!(4) {
+                    None => exit(1),
+                    Some("-b") => match argv!(5) {
+                        None => exit(1),
+                        Some(_) => exit(0) // Any argument will do, return 0
+                    },
                     Some(_) => exit(1)
                 },
 
@@ -56,16 +75,6 @@ fn main() {
             }
         },
 
-        // git checkout -b <anything>
-        Some("checkout") => match argv!(2) {
-            None => exit(1),
-            Some("-b") => match argv!(3) {
-                None => exit(1),
-                Some(_) => exit(0) // Any argument will do, return 0
-            },
-            Some(_) => exit(1)
-        },
-
         // git push -u origin <anything>
         Some("push") => match argv!(2) {
             None => exit(1),
@@ -80,15 +89,6 @@ fn main() {
             Some(_) => exit(1)
         },
 
-        Some("branch") => match argv!(2) {
-            None => exit(1),
-            Some("-d") => match argv!(3) {
-                None => exit(1),
-                Some("already-been-merged") => exit(0),
-                Some(_) => exit(1)
-            },
-            Some(_) => exit(1)
-        }
         // unrecognized input
         Some(_) => exit(1)
     };

--- a/src/bin/fake_git.rs
+++ b/src/bin/fake_git.rs
@@ -33,11 +33,23 @@ fn main() {
                 // git --version
                 Some("--version") => println!("fake_git version 1"),
 
+                // git branch --merged
                 Some("branch") => match argv!(4) {
                     None => exit(1),
                     Some("--merged") => println!("* trunk\nalready-been-merged"),
                     Some(_) => exit(1)
-                }
+                },
+
+                // git rev-parse --short HEAD
+                Some("rev-parse") => match argv!(4) {
+                    None => exit(1),
+                    Some("--short") => match argv!(5) {
+                        None => exit(1),
+                        Some("HEAD") => println!("1234567"),
+                        Some(_) => exit(1)
+                    },
+                    Some(_) => exit(1)
+                },
 
                 // unrecognized input
                 Some(_) => exit(1)
@@ -63,17 +75,6 @@ fn main() {
                     None => exit(1),
                     Some(_) => exit(0) // Any argument will do, return 0
                 },
-                Some(_) => exit(1)
-            },
-            Some(_) => exit(1)
-        },
-
-        // git rev-parse --short HEAD
-        Some("rev-parse") => match argv!(2) {
-            None => exit(1),
-            Some("--short") => match argv!(3) {
-                None => exit(1),
-                Some("HEAD") => println!("1234567"),
                 Some(_) => exit(1)
             },
             Some(_) => exit(1)

--- a/src/bin/fake_git.rs
+++ b/src/bin/fake_git.rs
@@ -33,6 +33,12 @@ fn main() {
                 // git --version
                 Some("--version") => println!("fake_git version 1"),
 
+                Some("branch") => match argv!(4) {
+                    None => exit(1),
+                    Some("--merged") => println!("* trunk\nalready-been-merged"),
+                    Some(_) => exit(1)
+                }
+
                 // unrecognized input
                 Some(_) => exit(1)
             }
@@ -80,7 +86,6 @@ fn main() {
                 Some("already-been-merged") => exit(0),
                 Some(_) => exit(1)
             },
-            Some("--merged") => println!("* trunk\nalready-been-merged"),
             Some(_) => exit(1)
         }
         // unrecognized input

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,9 @@ impl Git {
 
     /// Produce a list of PRs which are elligible for deletion.
     pub fn merged_branches(&self) -> Result<String,GitError> {
-        let output = Command::new(&self.program).args(&["branch","--merged","trunk"]).output()?;
+        let output = Command::new(&self.program)
+            .arg("-C").arg(self.working_dir.as_ref().as_ref())
+            .args(&["branch","--merged","trunk"]).output()?;
         assert_success(output.status)?;
 
         Ok(String::from_utf8_lossy(&output.stdout).to_string())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,9 @@ impl Git {
     /// local references to any that have been deleted. This ensures that the user is able to see
     /// the same set of "current PRs" as their collaborators.
     pub fn fetch_prune(&self) -> Result<(),GitError> {
-        let status = Command::new(&self.program).args(&["fetch","--prune"]).status()?;
+        let status = Command::new(&self.program)
+            .arg("-C").arg(self.working_dir.as_ref().as_ref())
+            .args(&["fetch","--prune"]).status()?;
         assert_success(status)?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,9 @@ impl Git {
     /// expressed as branches with a certain naming pattern (`pr-name/hash`). So in our system,
     /// creating a branch and creating a pull request are the same operation!
     pub fn create_branch(&self, name: &str) -> Result<(), GitError> {
-        let status = Command::new(&self.program).args(&["checkout","-b",name]).status()?;
+        let status = Command::new(&self.program)
+            .arg("-C").arg(self.working_dir.as_ref().as_ref())
+            .args(&["checkout","-b",name]).status()?;
         assert_success(status)?;
 
         Ok(())
@@ -147,7 +149,9 @@ impl Git {
     ///
     /// Won't delete unmerged branches.
     pub fn delete_branch(&self, name: &str) -> Result<(), GitError> {
-        let status = Command::new(&self.program).args(&["branch","-d",name]).status()?;
+        let status = Command::new(&self.program)
+            .arg("-C").arg(self.working_dir.as_ref().as_ref())
+            .args(&["branch","-d",name]).status()?;
         assert_success(status)?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,9 @@ impl Git {
     /// config value, and will return a hash of the indicated length. If this value is not
     /// specificed, git will return the shortest hash necessary to uniquely identify the commit.
     pub fn rev_parse_head(&self) -> Result<String,GitError> {
-        let output = Command::new(&self.program).args(&["rev-parse","--short","HEAD"]).output()?;
+        let output = Command::new(&self.program)
+            .arg("-C").arg(self.working_dir.as_ref().as_ref())
+            .args(&["rev-parse","--short","HEAD"]).output()?;
         assert_success(output.status)?;
 
         Ok(String::from_utf8_lossy(&output.stdout).trim_end().to_string())

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -1,87 +1,72 @@
 //! Test the git "client" wrapper against the real git binary.
-use lazy_static::lazy_static;
 use libgitpr::Git;
-use std::env::set_current_dir;
-use std::path::Path;
 use std::process::Command;
+use std::process::Stdio;
 use tempdir::TempDir;
 
-struct TestState {
-    working_dir: TempDir
+// Implementing this above produces a warning, since the function is (by design) never used by
+// other application code. Since it is only used in this module, we implement this function
+// local to this module, thus eliminating the dead code warning.
+fn temp_repo() -> Git {
+    let working_dir = Box::new(TempDir::new("git-pr").unwrap());
+
+    // git init in new unique dir
+    let status = Command::new("git")
+        .stdout(Stdio::null())
+        .arg("-C").arg(working_dir.as_ref().as_ref())
+        .args(&["init"]).status().unwrap();
+    assert!(status.success());
+
+    // Setup git config for email
+    let status = Command::new("git")
+        .arg("-C").arg(working_dir.as_ref().as_ref())
+        .args(&["config","user.email","you@example.com"]).status().unwrap();
+    assert!(status.success());
+
+    // Setup git config for name
+    let status = Command::new("git")
+        .arg("-C").arg(working_dir.as_ref().as_ref())
+        .args(&["config","user.name","Your Name"]).status().unwrap();
+    assert!(status.success());
+
+    // create trunk branch
+    let status = Command::new("git")
+        .arg("-C").arg(working_dir.as_ref().as_ref())
+        .args(&["checkout","-b","trunk"]).status().unwrap();
+    assert!(status.success());
+
+    // empty commit to actually create trunk branch
+    let status = Command::new("git")
+        .arg("-C").arg(working_dir.as_ref().as_ref())
+        .args(&["commit","--allow-empty","-m","hello"]).status().unwrap();
+    assert!(status.success());
+
+    // create a fake branch to test deletion
+    let status = Command::new("git")
+        .arg("-C").arg(working_dir.as_ref().as_ref())
+        .args(&["branch","hotfix"]).status().unwrap();
+    assert!(status.success());
+
+    Git{ program: "git".to_string(), working_dir }
 }
 
-impl TestState {
-    fn new(prefix: &str) -> Self {
-        let working_dir = TempDir::new(prefix).unwrap();
-        set_current_dir(working_dir.path()).unwrap();
-
-        // git init in new unique dir
-        let status = Command::new("git").args(&["init"]).status().unwrap();
-        assert!(status.success());
-
-        // Setup git config for email
-        let status = Command::new("git")
-            .args(&["config","user.email","you@example.com"]).status().unwrap();
-        assert!(status.success());
-
-        // Setup git config for name
-        let status = Command::new("git")
-            .args(&["config","user.name","Your Name"]).status().unwrap();
-        assert!(status.success());
-
-        // create trunk branch
-        let status = Command::new("git").args(&["checkout","-b","trunk"]).status().unwrap();
-        assert!(status.success());
-
-        // empty commit to actually create trunk branch
-        let status = Command::new("git")
-            .args(&["commit","--allow-empty","-m","hello"]).status().unwrap();
-        assert!(status.success());
-
-        // create a fake branch to test deletion
-        let status = Command::new("git").args(&["branch","hotfix"]).status().unwrap();
-        assert!(status.success());
-
-        Self{ working_dir }
-    }
-
-    fn path(&self) -> &Path {
-        self.working_dir.path()
-    }
-}
-
-lazy_static! {
-    static ref TEST_STATE: TestState = TestState::new("git_pr_test");
-}
-
-macro_rules! init_test_state {
-    () => {
-        println!("TempDir='{:?}'", TEST_STATE.path());
-    };
-}
 
 #[test]
 fn version() {
-    init_test_state!();
-
-    let git = Git::new();
+    let git = temp_repo();
     let version = git.version().unwrap();
     assert!(version.starts_with("git version 2"));
 }
 
 #[test]
 fn fetch_and_prune() {
-    init_test_state!();
-
-    let git = Git::new();
+    let git = temp_repo();
     git.fetch_prune().unwrap();
 }
 
 #[test]
 fn can_list_all_branches() {
-    init_test_state!();
-
-    let git = Git::new();
+    let git = temp_repo();
     let branches = git.all_branches().unwrap();
     assert!(branches.contains("trunk"));
 }
@@ -93,9 +78,7 @@ fn can_list_all_branches() {
 // order to implement the "pr-clean" subcommand.
 #[test]
 fn could_clean() {
-    init_test_state!();
-
-    let git = Git::new();
+    let git = temp_repo();
     let branches = git.merged_branches().unwrap();
     assert!(branches.contains("hotfix"));
 
@@ -106,23 +89,19 @@ fn could_clean() {
 
 #[test]
 fn can_get_hash_of_head() {
-    init_test_state!();
-
     // The hash will change every time, but this is one of the few git commands for which we can
     // know the exact length of the output. Weak, but best we can do until we add more capabilities
     // to the client.
-    let git = Git::new();
+    let git = temp_repo();
     let hash = git.rev_parse_head().unwrap();
     assert_eq!(hash.len(), 7);
 }
 
 #[test]
 fn can_create_new_branch() {
-    init_test_state!();
-
     // Show that we can create a new branch in this repo, and verify its existence by querying the
     // list of branches and showing that this new branch is among them.
-    let git = Git::new();
+    let git = temp_repo();
     git.create_branch("knurt").unwrap();
     let branches = git.all_branches().unwrap();
     assert!(branches.contains("knurt"));


### PR DESCRIPTION
This is a proof of concept for re-introducing the `tempdir` package and using it to create a git repository for each test. By adding a `working_dir` field to the Git client wrapper, it can run all of its git commands with the `-C` flag, as in:

```sh
git -C /tmp/dir/git-pr-test-12345 branch -va
```

According to [GIT(1)][1], the `-C <DIR>` option instructs git to run as though it had been launched from `DIR`, even if `DIR` is not the current working directory of the parent process. Given that we cannot change the working directory of `cargo test` (since it runs tests as threads of a single process, and the notion of a "working directory" is a process-level property), this should give us exactly what we want.

**Caveat.** The temporary repositories do not seem to actually get deleted on my mac. The [TempDir docs][2] seem to anticipate this:
> Various platform-specific conditions may cause TempDir to fail to delete the underlying directory.

So, perhaps this is all for naught. 🤷

[1]: https://www.man7.org/linux/man-pages/man1/git.1.html
[2]: https://docs.rs/tempdir/0.3.7/tempdir/struct.TempDir.html