### PR TITLE
Custom types to distinguish git output

### DIFF
--- a/src/bin/git-pr-clean.rs
+++ b/src/bin/git-pr-clean.rs
@@ -5,8 +5,8 @@ fn main() -> Result<(),libgitpr::GitError> {
     let git = libgitpr::Git::new();
     let merged_branches = git.merged_branches()?;
 
-    for branch in libgitpr::extract_deletable_branches(&merged_branches) {
-        git.delete_branch(&branch)?;
+    for branch in merged_branches.filter(|b| !b.is_head) {
+        git.delete_branch(&branch.name.value)?;
     }
 
     Ok(())

--- a/src/branch_name.rs
+++ b/src/branch_name.rs
@@ -1,0 +1,59 @@
+//! Deal with branches by their filesystem-like names.
+//!
+//! The only thing this module does is to check whether a branch name looks like it belongs to a
+//! PR. That is the only thing that local branches and remote branches have in common.
+use std::str::FromStr;
+use regex::Regex;
+
+
+/// A filesystem-like name for a branch
+#[derive(Debug)]
+pub struct BranchName {
+    pub value: String
+}
+
+
+impl BranchName {
+    /// Does the branch name match our `pr/naming/schema/123abc`?
+    pub fn looks_like_pr(&self) -> bool {
+        let ends_with_hex: Regex = Regex::new(r"/[a-f\d]+$").unwrap();
+        ends_with_hex.is_match(&self.value)
+    }
+}
+
+impl FromStr for BranchName {
+
+    // We are not using any methods that can fail, so we don't need an error type.
+    type Err = std::convert::Infallible;
+
+    /// Convert a `&str` into a BranchName
+    ///
+    /// This will allow us to manipulate the branch name with the methods from `impl BranchName`
+    /// rather than (potentially clunkier) string-manipulation methods.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(BranchName{ value: String::from(s) })
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_parse() {
+        let _: BranchName = "trunk".parse().unwrap();
+    }
+
+    #[test]
+    fn trunk_is_not_a_pr() {
+        let trunk = "trunk".parse::<BranchName>().unwrap();
+        assert!(!trunk.looks_like_pr());
+    }
+
+    #[test]
+    fn can_identify_a_pr() {
+        let pr_branch = BranchName::from_str("pr-name/abc123").unwrap();
+        assert!(pr_branch.looks_like_pr());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,18 @@
 //! Pull request management for bare repos
 
 mod branch_name;
-mod list_of;
 mod local_branch;
+mod output_list;
 
-use list_of::ListOf;
 use local_branch::LocalBranch;
+use output_list::OutputList;
 use regex::Regex;
 use std::io;
 use std::path::Path;
 use std::process::Command;
 use std::process::ExitStatus;
 
-pub type LocalBranches = ListOf<LocalBranch>;
+pub type LocalBranches = OutputList<LocalBranch>;
 
 /// Wrapper for the git command line program
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 
 use regex::Regex;
+use std::fmt;
 use std::io;
 use std::path::Path;
 use std::process::Command;
@@ -52,6 +53,16 @@ fn assert_success(status: ExitStatus) -> Result<(),GitError> {
     match status.success() {
         true => Ok(()),
         false => Err(GitError::Exit(status))
+    }
+}
+
+pub struct ShortHash {
+    content: String
+}
+
+impl fmt::Display for ShortHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.content)
     }
 }
 
@@ -122,13 +133,14 @@ impl Git {
     /// indicate the "base" of the current work. This function takes advantage of the `core.abbrev`
     /// config value, and will return a hash of the indicated length. If this value is not
     /// specificed, git will return the shortest hash necessary to uniquely identify the commit.
-    pub fn rev_parse_head(&self) -> Result<String,GitError> {
+    pub fn rev_parse_head(&self) -> Result<ShortHash,GitError> {
         let output = Command::new(&self.program)
             .arg("-C").arg(self.working_dir.as_ref().as_ref())
             .args(&["rev-parse","--short","HEAD"]).output()?;
         assert_success(output.status)?;
 
-        Ok(String::from_utf8_lossy(&output.stdout).trim_end().to_string())
+        let content = String::from_utf8_lossy(&output.stdout).trim_end().to_string();
+        Ok(ShortHash{ content })
     }
 
     /// Create a new branch

--- a/src/list_of.rs
+++ b/src/list_of.rs
@@ -1,0 +1,50 @@
+//! A "List of <T>".
+//!
+//! Assuming T is `FromStr`, and you have lines of T source text, this will convert them into an
+//! iterable container of T.
+use std::str::FromStr;
+
+pub struct ListOf<T: FromStr> {
+    storage: Vec<T>
+}
+
+impl<T: FromStr> FromStr for ListOf<T> {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let storage = s.lines()
+            .filter_map(|line| line.parse::<T>().ok())
+            .rev().collect();
+
+        Ok(Self{ storage })
+    }
+}
+
+impl<T: FromStr> Iterator for ListOf<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.storage.pop()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_parse_list_of_numbers() {
+        let source = "1\n2\nthree\n4";
+
+        let list = source.parse::<ListOf<u8>>().unwrap();
+        assert_eq!(list.storage.len(), 3);
+    }
+
+    #[test]
+    fn can_iterate_list_of_numbers() {
+        let source = "1\n2\nthree\n4";
+
+        let list = source.parse::<ListOf<u8>>().unwrap();
+        assert_eq!(list.collect::<Vec<u8>>(), vec![1,2,4]);
+    }
+}

--- a/src/local_branch.rs
+++ b/src/local_branch.rs
@@ -1,0 +1,67 @@
+//! Parse the names of local branches
+
+use crate::branch_name::BranchName;
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub enum ParseError {
+    MissingName
+}
+
+#[derive(Debug)]
+pub struct LocalBranch {
+    pub name: BranchName,
+    pub is_head: bool
+}
+
+impl LocalBranch {
+    pub fn new(is_head: bool, name: &str) -> Self {
+        // It's always safe to unwrap this since BranchName::parse is [`Infallible`].
+        let name = name.parse::<BranchName>().unwrap();
+        Self{ is_head, name }
+    }
+    pub fn looks_like_pr(&self) -> bool {
+        self.name.looks_like_pr()
+    }
+}
+
+impl FromStr for LocalBranch {
+    type Err = ParseError;
+
+    fn from_str(line: &str) -> Result<Self, Self::Err> {
+        let mut components = line.split_whitespace();
+
+        // The line will either look like "  branch/name" or "* branch/name". If it doesn't, then
+        // something is wrong with git.
+        match components.next() {
+            None => Err(ParseError::MissingName),
+            Some("*") => match components.next() {
+                None => Err(ParseError::MissingName),
+                Some(name) => Ok(LocalBranch::new(true, name))
+            },
+            Some(name) => Ok(LocalBranch::new(false, name))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_parse() {
+        let _: LocalBranch = "trunk".parse().unwrap();
+    }
+
+    #[test]
+    fn can_detect_head() {
+        let trunk: LocalBranch = "* trunk".parse().unwrap();
+        assert!(trunk.is_head);
+    }
+
+    #[test]
+    fn unstarred_branches_are_not_head() {
+        let other: LocalBranch = "  other/branch/123abc".parse().unwrap();
+        assert!(!other.is_head);
+    }
+}

--- a/src/output_list.rs
+++ b/src/output_list.rs
@@ -4,11 +4,11 @@
 //! iterable container of T.
 use std::str::FromStr;
 
-pub struct ListOf<T: FromStr> {
+pub struct OutputList<T: FromStr> {
     storage: Vec<T>
 }
 
-impl<T: FromStr> FromStr for ListOf<T> {
+impl<T: FromStr> FromStr for OutputList<T> {
     type Err = std::convert::Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -20,7 +20,7 @@ impl<T: FromStr> FromStr for ListOf<T> {
     }
 }
 
-impl<T: FromStr> Iterator for ListOf<T> {
+impl<T: FromStr> Iterator for OutputList<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -36,7 +36,7 @@ mod tests {
     fn can_parse_list_of_numbers() {
         let source = "1\n2\nthree\n4";
 
-        let list = source.parse::<ListOf<u8>>().unwrap();
+        let list = source.parse::<OutputList<u8>>().unwrap();
         assert_eq!(list.storage.len(), 3);
     }
 
@@ -44,7 +44,7 @@ mod tests {
     fn can_iterate_list_of_numbers() {
         let source = "1\n2\nthree\n4";
 
-        let list = source.parse::<ListOf<u8>>().unwrap();
+        let list = source.parse::<OutputList<u8>>().unwrap();
         assert_eq!(list.collect::<Vec<u8>>(), vec![1,2,4]);
     }
 }

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -79,8 +79,8 @@ fn can_list_all_branches() {
 #[test]
 fn could_clean() {
     let git = temp_repo();
-    let branches = git.merged_branches().unwrap();
-    assert!(branches.contains("hotfix"));
+    let mut branches = git.merged_branches().unwrap();
+    assert!(branches.any(|b| &b.name.value == "hotfix"));
 
     git.delete_branch("hotfix").unwrap();
     let branches = git.all_branches().unwrap();


### PR DESCRIPTION
The output from different git commands has structure and is not actually interchangeable, but we treat it all like it's a String.