### PR TITLE
Thin types to distinguish branch output. Fixes #51.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,20 @@ fn assert_success(status: ExitStatus) -> Result<(),GitError> {
     }
 }
 
+
+/// Output from `git branch -a`
+///
+/// This type wraps the output from `git branch -a`, and gives us a way to leverage Rust's type
+/// system to treat this differently from other git output.
 pub struct AllBranches {
     pub value: String
 }
 
+
+/// Output from `git branch --merged`
+///
+/// This type wraps the output from `git branch --merged`, and gives us a way to leverage Rust's
+/// type system to treat this differently from other git output.
 pub struct MergedBranches {
     pub value: String
 }

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -68,7 +68,7 @@ fn fetch_and_prune() {
 fn can_list_all_branches() {
     let git = temp_repo();
     let branches = git.all_branches().unwrap();
-    assert!(branches.contains("trunk"));
+    assert!(branches.value.contains("trunk"));
 }
 
 // Cleaning PRs requires that we identify "old" branches (those which have been merged into trunk),
@@ -80,11 +80,11 @@ fn can_list_all_branches() {
 fn could_clean() {
     let git = temp_repo();
     let branches = git.merged_branches().unwrap();
-    assert!(branches.contains("hotfix"));
+    assert!(branches.value.contains("hotfix"));
 
     git.delete_branch("hotfix").unwrap();
     let branches = git.all_branches().unwrap();
-    assert!(!branches.contains("hotfix"));
+    assert!(!branches.value.contains("hotfix"));
 }
 
 #[test]
@@ -104,5 +104,5 @@ fn can_create_new_branch() {
     let git = temp_repo();
     git.create_branch("knurt").unwrap();
     let branches = git.all_branches().unwrap();
-    assert!(branches.contains("knurt"));
+    assert!(branches.value.contains("knurt"));
 }


### PR DESCRIPTION
`git branch -a` and `git branch --merged trunk` produce different kinds
of output, and can't easily be parsed the same way. This commit
introduces two types, AllBranches and MergedBranches, which wrap the
underlying string output, and serve only to disambiguate which functions
can be used against which kinds of values.

There is *a lot* more that we can refactor here, but I wanted to create
the smallest possible solution to #51.